### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Borsa MCP: Türk Finans Piyasaları için MCP Sunucusu
 
-[![Star History Chart](https://api.star-history.com/svg?repos=saidsurucu/borsa-mcp&type=Date)](https://www.star-history.com/#saidsurucu/borsa-mcp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=saidsurucu/borsa-mcp&type=Date)](https://star-history.dera.page/#saidsurucu/borsa-mcp&Date)
 
 Borsa İstanbul (BIST) ve ABD (US) hisseleri, TEFAS fonları, kripto paralar ve döviz/emtia verilerine LLM'ler üzerinden erişim sağlayan [FastMCP](https://gofastmcp.com/) sunucusu. KAP, Yahoo Finance, BtcTurk, Coinbase, borsapy ve TCMB gibi kaynaklardan **26 birleşik araç** ile kapsamlı finansal analiz.
 


### PR DESCRIPTION
The star history chart on the README is currently broken: GitHub's stargazer API restrictions prevent the old endpoint from rendering. This change points the chart (and its link) at star-history.dera.page, an alternative provider that needs no API token, so the badge shows correctly again.